### PR TITLE
Adding support for Custom Model Data in the recipes

### DIFF
--- a/src/main/java/com/snowgears/grapplinghook/utils/RecipeLoader.java
+++ b/src/main/java/com/snowgears/grapplinghook/utils/RecipeLoader.java
@@ -65,6 +65,7 @@ public class RecipeLoader {
                 boolean lineBreak = config.getBoolean("recipes." + recipeNumber + ".lineBreak");
                 boolean airHook = config.getBoolean("recipes." + recipeNumber + ".airHook");
                 boolean stickyHook = config.getBoolean("recipes." + recipeNumber + ".stickyHook");
+                int customModelData = config.getInt("recipes." + recipeNumber + ".customModelData", 0);
 
                 try {
                     List<String> entityBlackList = config.getStringList("recipes." + recipeNumber + ".entityBlacklist");
@@ -83,6 +84,8 @@ public class RecipeLoader {
                     }
                     hookItemMeta.setLore(loreList);
                 }
+
+                hookItemMeta.setCustomModelData(Integer.valueOf(customModelData));
 
                 PersistentDataContainer persistentData = hookItemMeta.getPersistentDataContainer();
                 persistentData.set(new NamespacedKey(plugin, "timeBetweenGrapples"), PersistentDataType.INTEGER, timeBetweenGrapples);

--- a/src/main/resources/recipes.yml
+++ b/src/main/resources/recipes.yml
@@ -32,6 +32,7 @@ recipes:
     name: '&6Wood Grappling Hook'
     lore:
       - '&7Uses left - &a[uses]'
+    customModelData: 110
     uses: 5
     velocityThrow: 1.0
     velocityPull: 1.0
@@ -57,6 +58,7 @@ recipes:
     name: '&6Stone Grappling Hook'
     lore:
       - '&7Uses left - &a[uses]'
+    customModelData: 120
     uses: 10
     velocityThrow: 1.0
     velocityPull: 1.0
@@ -82,6 +84,7 @@ recipes:
     name: '&6Iron Grappling Hook'
     lore:
       - '&7Uses left - &a[uses]'
+    customModelData: 130
     uses: 20
     velocityThrow: 1.0
     velocityPull: 1.0
@@ -107,6 +110,7 @@ recipes:
     name: '&6Gold Grappling Hook'
     lore:
       - '&7Uses left - &a[uses]'
+    customModelData: 140
     uses: 25
     velocityThrow: 1.0
     velocityPull: 1.0
@@ -132,6 +136,7 @@ recipes:
     name: '&6Emerald Grappling Hook'
     lore:
       - '&7Uses left - &a[uses]'
+    customModelData: 150
     uses: 40
     velocityThrow: 1.0
     velocityPull: 1.0
@@ -157,6 +162,7 @@ recipes:
     name: '&6Diamond Grappling Hook'
     lore:
       - '&7Uses left - &a[uses]'
+    customModelData: 160
     uses: 100
     velocityThrow: 1.0
     velocityPull: 1.0


### PR DESCRIPTION
Support for Custom Model Data in recipes has been added. This will allow you to create resource packs with custom textures applied to the fishing rod.

For this you just have to create a new model and texture in your resource pack and apply it to the existing item of the fishing rod, ex.

`assets/minecraft/models/item/grappling_hook.json`
```json
{
    "parent": "item/generated",
    "textures": {
        "layer0": "item/grappling_hook"
    }
}
```

`assets/minecraft/models/item/fishing_rod.json`
```json
{
    "parent": "item/generated",
    "textures": {
        "layer0": "item/fishing_rod"
    },
    "overrides": [
        { "predicate": { "custom_model_data": 110 }, "model": "item/grappling_hook" },
    ]
}

```